### PR TITLE
Add generated jar as a project artifact when archiveClasses=true

### DIFF
--- a/src/main/java/org/mule/tools/maven/plugin/MuleMojo.java
+++ b/src/main/java/org/mule/tools/maven/plugin/MuleMojo.java
@@ -163,7 +163,8 @@ public class MuleMojo extends AbstractMuleMojo
         }
         else
         {
-            addArchivedClasses(archiver);
+            File jar = addArchivedClasses(archiver);
+            this.projectHelper.attachArtifact(this.project, "jar", jar);
         }
     }
 
@@ -193,12 +194,12 @@ public class MuleMojo extends AbstractMuleMojo
         }
     }
 
-    private void addArchivedClasses(MuleArchiver archiver) throws ArchiverException, MojoExecutionException
+    private File addArchivedClasses(MuleArchiver archiver) throws ArchiverException, MojoExecutionException
     {
         if (this.classesDirectory.exists() == false)
         {
             getLog().info(this.classesDirectory + " does not exist, skipping");
-            return;
+            return null;
         }
 
         getLog().info("Copying classes as a jar");
@@ -218,6 +219,7 @@ public class MuleMojo extends AbstractMuleMojo
             getLog().error(message, e);
             throw new MojoExecutionException(message, e);
         }
+        return jar;
     }
 
     private void addDependencies(MuleArchiver archiver) throws ArchiverException

--- a/src/main/java/org/mule/tools/maven/plugin/MuleMojo.java
+++ b/src/main/java/org/mule/tools/maven/plugin/MuleMojo.java
@@ -164,7 +164,10 @@ public class MuleMojo extends AbstractMuleMojo
         else
         {
             File jar = addArchivedClasses(archiver);
-            this.projectHelper.attachArtifact(this.project, "jar", jar);
+            if(jar != null)
+            {
+            	this.projectHelper.attachArtifact(this.project, "jar", jar);
+            }
         }
     }
 


### PR DESCRIPTION
I found that the jar generated by the mule plugin was not added to the artifacts of the project which, in my case, prevented other plugins to "see it" in the following lifecycle phases.
This patch solves the above use-case and should be safe to apply.
More work might be required wrt having an associated pom for this artifact.